### PR TITLE
Remove to delete tlsClientAuth from cf

### DIFF
--- a/functions/_logtail.ts
+++ b/functions/_logtail.ts
@@ -37,9 +37,6 @@ export default class Logtail {
     const {request} = context;
     const response = await context.next();
 
-    const cf = request.cf;
-    delete cf.tlsExportedAuthenticator;
-
     const log = JSON.stringify({
       dt: new Date().toISOString(),
       level: 'info',
@@ -53,7 +50,7 @@ export default class Logtail {
           url: request.url,
           method: request.method,
           headers: this.metadataFromHeaders(request.headers),
-          cf: cf,
+          cf: request.cf,
         },
         response: {
           headers: this.metadataFromHeaders(response.headers),

--- a/functions/_logtail.ts
+++ b/functions/_logtail.ts
@@ -38,7 +38,6 @@ export default class Logtail {
     const response = await context.next();
 
     const cf = request.cf;
-    delete cf.tlsClientAuth;
     delete cf.tlsExportedAuthenticator;
 
     const log = JSON.stringify({


### PR DESCRIPTION
It seems that CF has started to prevent deleting properties.

<img width="1057" alt="image" src="https://github.com/taehoio/OneononeApp/assets/538584/d5a1400c-24d8-46a3-b516-029914328cc1">

<img width="1097" alt="image" src="https://github.com/taehoio/OneononeApp/assets/538584/518d090a-7757-4f20-b554-a99663182528">
